### PR TITLE
Fix empty body check in request mapping

### DIFF
--- a/scripts/lua/policies/mapping.lua
+++ b/scripts/lua/policies/mapping.lua
@@ -188,7 +188,7 @@ function transformAllParams(s, d)
 end
 
 function finalize()
-  if #body > 0 then 
+  if next(body) ~= nil then
     local bodyJson = cjson.encode(body)
     ngx.req.set_body_data(bodyJson)
   end


### PR DESCRIPTION
Fixed checking for an empty `body` table.