### PR TITLE
remove redis.close causing intermittent failures

### DIFF
--- a/scripts/lua/oauth/github.lua
+++ b/scripts/lua/oauth/github.lua
@@ -30,7 +30,6 @@ function validateOAuthToken (red, token)
   local httpc = http.new()
   local key = utils.concatStrings({'oauth:provider:github:', token})
   if redis.exists(red, key) == 1 then
-    redis.close(red)
     return cjson.decode(redis.get(red, key))
   end
  

--- a/scripts/lua/oauth/google.lua
+++ b/scripts/lua/oauth/google.lua
@@ -29,7 +29,6 @@ function validateOAuthToken (red, token)
   local httpc = http.new()
   local key = utils.concatStrings({'oauth:provider:google:', token})
   if redis.exists(red, key) == 1 then
-    redis.close(red)
     return cjson.decode(redis.get(red, key))
   end
 

--- a/scripts/lua/policies/security/oauth2.lua
+++ b/scripts/lua/policies/security/oauth2.lua
@@ -74,7 +74,6 @@ end
 -- @return the json object recieved from exchanging tokens with the provider
   function exchangeWithRedis(red, token, provider)
     -- exchange tokens with the provider
-    print (provider)
     local loaded, provider = pcall(require, utils.concatStrings({'oauth/', provider}))
  
     if not loaded then


### PR DESCRIPTION
I was calling redis.close twice which sometimes can fail if the second call happens after redis is already closed.