### PR TITLE
Revert "Remove the CLI gradle build in Travis CI (#232)"

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -32,6 +32,8 @@ $ANSIBLE_CMD apigateway.yml -e apigateway_local_build=true
 
 cd $WHISKDIR
 
+TERM=dumb ./gradlew tools:cli:distDocker -PdockerImagePrefix=openwhisk
+
 cd $WHISKDIR/ansible
 
 


### PR DESCRIPTION
This reverts commit ddea5c9095f3798305320181247abafa41b7abc1.

@mhamann or @houshengbo could you review and merge this.

Closes #233 