### PR TITLE
Remove Swift3 reference from Travis build

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -3,7 +3,7 @@ set -e
 set -x
 
 # Build script for Travis-CI.
-SCRIPTDIR=$(cd $(dirname "$0") && pwd)
+SCRIPTDIR="$(cd "$(dirname "$0")" && pwd)"
 ROOTDIR="$SCRIPTDIR/../.."
 HOMEDIR="$ROOTDIR/.."
 WHISKDIR="$ROOTDIR/../openwhisk"
@@ -45,7 +45,7 @@ export OPENWHISK_HOME=$WHISKDIR
 cd $WHISKDIR
 cat whisk.properties
 
-WSK_TESTS_DEPS_EXCLUDE="-x :actionRuntimes:swift3Action:distDocker -x :actionRuntimes:pythonAction:distDocker -x :actionRuntimes:javaAction:distDocker -x :actionRuntimes:nodejsAction:distDocker -x :actionRuntimes:actionProxy:distDocker -x :sdk:docker:distDocker -x :actionRuntimes:python2Action:distDocker -x :tests:dat:blackbox:badaction:distDocker -x :tests:dat:blackbox:badproxy:distDocker"
+WSK_TESTS_DEPS_EXCLUDE="-x :actionRuntimes:pythonAction:distDocker -x :actionRuntimes:javaAction:distDocker -x :actionRuntimes:nodejs6Action:distDocker -x :actionRuntimes:nodejs8Action:distDocker -x :actionRuntimes:actionProxy:distDocker -x :sdk:docker:distDocker -x :actionRuntimes:python2Action:distDocker -x :tests:dat:blackbox:badaction:distDocker -x :tests:dat:blackbox:badproxy:distDocker"
 
 TERM=dumb ./gradlew tests:test --tests apigw.healthtests.* ${WSK_TESTS_DEPS_EXCLUDE}
 sleep 60


### PR DESCRIPTION
The travis build fails because a Gradle action in the testing portion of 'tools/travis/build.sh' refers to the no-longer-existing swift 3 action.  This patch removes that reference and corrects a lint warning while it's at it.

I have an Apache CLA in place.