### PR TITLE
Use gmatch instead of gfind

### DIFF
--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -200,7 +200,7 @@ end
 -- @param resourceKey redis resourceKey to check if it matches path parameter
 function _M.pathParamMatch(key, resourceKey)
   local pathParamVars = {}
-  for w in string.gfind(key, "({%w+})") do
+  for w in string.gmatch(key, "({%w+})") do
     w = string.sub(w, 2, string.len(w) - 1)
     pathParamVars[#pathParamVars + 1] = w
   end


### PR DESCRIPTION
@mhamann 
Lua's `string.gfind` function is deprecated and has been and renamed to `string.gmatch`