### PR TITLE
Sync the Gateway configuration with a remote location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # apigateway
 #
-# VERSION               1.9.7.3
+# VERSION               1.13.6.1
 #
 # From https://hub.docker.com/_/alpine/
 #
@@ -211,6 +211,10 @@ RUN echo " ... installing cjose ... " \
     && sh configure \
     && make && make install \
     && rm -rf /tmp/api-gateway
+
+ENV CONFIG_SUPERVISOR_VERSION 1.0.1-RC1
+COPY build_config_supervisor.sh /tmp/build_config_supervisor.sh 
+RUN sh +x /tmp/build_config_supervisor.sh 
 
 COPY init.sh /etc/init-container.sh
 # add the default configuration for the Gateway

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ docker run -p 80:80 -p <managedurl_port>:8080 -p 9000:9000 \
 The Gateway can sync its configuration with a remote folder in the cloud such as Amazon S3, Google Cloud Storage, IBM Cloud Object Storage, Dropbox, and [many others](https://rclone.org/). The configuration is monitored for changes, and when a file is changed, the Gateway is reloaded automatically. This is very useful to gracefully update the Gateway on the fly, without impacting the active traffic; if the new configuration is invalid, the Gateway doesn't break, running with the last known valid configuration.
 
 This feature is enabled by configuring a few environment variables:
-* `REMOTE_CONFIG` - the location where the config should be synced from. I.e. `s3://api-gateway-config` . The remote location is synced into is `/etc/api-gateway`.
+* `REMOTE_CONFIG` - the location where the configuration should be synced from. I.e. `s3://api-gateway-config` . The remote location is synced into is `/etc/api-gateway`.
+The default configuration is found in this project's root folder.
 * (optional) `REMOTE_CONFIG_SYNC_INTERVAL` - how often to check for changes in the remote location. The default value is `10s`
 * (optional) `REMOTE_CONFIG_RELOAD_CMD` - which command to execute in order to reload the Gateway. The default value is: `api-gateway -s reload`
 
@@ -73,7 +74,7 @@ This runs an interactive `rclone config` command and stores the resulted configu
 To test this locally, _simulate_ a remote folder using a local location, by mounting it in `/tmp` folder as follows:
 
 ```bash
-docker run -ti --rm -p 80:80  \ 
+docker run -ti --rm -p 80:80 \
     -v `pwd`:/tmp/api-gateway-local -e REMOTE_CONFIG="/tmp/api-gateway-local" \
     -e REDIS_HOST=redis_host -e REDIS_PORT=redis_port openwhisk/apigateway
 ```

--- a/build_config_supervisor.sh
+++ b/build_config_supervisor.sh
@@ -1,0 +1,40 @@
+#ENV CONFIG_SUPERVISOR_VERSION 1.0.1-RC1
+export GOPATH=/usr/lib/go/bin
+export GOBIN=/usr/lib/go/bin
+export PATH=$PATH:/usr/lib/go/bin
+echo " ... installing api-gateway-config-supervisor  ... " \
+apk update 
+apk add gcc make git go 
+mkdir -p /tmp/api-gateway 
+curl -k -L https://github.com/adobe-apiplatform/api-gateway-config-supervisor/archive/${CONFIG_SUPERVISOR_VERSION}.tar.gz -o /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz 
+cd /tmp/api-gateway
+tar -xf /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}.tar.gz
+mkdir -p /tmp/go
+mv /tmp/api-gateway/api-gateway-config-supervisor-${CONFIG_SUPERVISOR_VERSION}/* /tmp/go
+cd /tmp/go
+make setup
+mkdir -p /tmp/go/Godeps/_workspace
+ln -s /tmp/go/vendor /tmp/go/Godeps/_workspace/src
+mkdir -p /tmp/go-src/src/github.com/adobe-apiplatform
+ln -s /tmp/go /tmp/go-src/src/github.com/adobe-apiplatform/api-gateway-config-supervisor
+GOPATH=/tmp/go/vendor:/tmp/go-src CGO_ENABLED=0 GOOS=linux /usr/lib/go/bin/godep  go build -ldflags "-s" -a -installsuffix cgo -o api-gateway-config-supervisor ./
+mv /tmp/go/api-gateway-config-supervisor /usr/local/sbin/
+
+echo "installing rclone sync ... " 
+go get github.com/ncw/rclone
+mv /usr/lib/go/bin/rclone /usr/local/sbin/ 
+mkdir -p /root/.config/rclone/
+cat <<EOF > /root/.config/rclone/rclone.conf
+[local] 
+type = local 
+nounc = true
+EOF
+
+echo " cleaning up ... " 
+rm -rf /usr/lib/go/bin/src
+rm -rf /tmp/go
+rm -rf /tmp/go-src
+rm -rf /usr/lib/go/bin/pkg/
+rm -rf /usr/lib/go/bin/godep
+apk del make git go gcc
+rm -rf /var/cache/apk/*

--- a/conf.d/includes/basic_endpoints.conf
+++ b/conf.d/includes/basic_endpoints.conf
@@ -38,16 +38,30 @@ location / {
 
 location /health-check {
     access_log off;
-    content_by_lua '
-        ngx.say("API-Platform is running!")
+    default_type application/json;
+    content_by_lua_block {
+        local cjson = require "cjson"
+        local s = {}
+        s.status = "API-Gateway is running"        
         if jit then
-            ngx.say("LuaJIT-" .. jit.version);
+            s.lua_version = jit.version
         else
-            ngx.say("LuaJIT is not enabled");
+            s.lua_version = "LuaJIT is not enabled"
         end
-    ';
+
+        local config_status = ngx.location.capture("/config-status");
+        if (config_status) then
+            s.config = cjson.decode(config_status.body)
+        end
+
+        ngx.say(cjson.encode(s))
+    }
 }
 
+location /config-status {
+  access_log off;
+  proxy_pass http://127.0.0.1:8888/health-check;
+}
 
 
 location /RequestDenied {


### PR DESCRIPTION
This PR introduces the capability for the Gateway to sync its configuration with a remote folder in the cloud such as Amazon S3, Google Cloud Storage, IBM Cloud Object Storage, Dropbox, and [many others](https://rclone.org/). The configuration is monitored for changes, and when a file is changed, the Gateway is reloaded automatically. This is very useful to gracefully update the Gateway on the fly, without impacting the active traffic; if the new configuration is invalid, the Gateway doesn't break, running with the last known valid configuration.

See the updated README for more details.

Other changes:
- [x] Updated the existing `/health-check` endpoint to also print information on the config, such as when it was last updated, or when was the Gateway last reloaded:
```javascript
  {
  "lua_version": "LuaJIT 2.1.0-beta3",
  "status": "API-Gateway is running",
  "config": {
    "lastChangeDetected": "2018-04-24T20:44:59.6466131Z",
    "lastReload": "2018-04-24T20:45:00.653188Z",
    "status": "OK",
    "lastSync": "2018-04-24T20:47:52.1896511Z"
    }  
  }
```

## Types of changes

- [x] Enhancement or new feature (adds new functionality).