### PR TITLE
Update managed API timeout

### DIFF
--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -71,6 +71,8 @@ server {
         set $responseHeaders '';
         set $responseBody '';
 
+        proxy_read_timeout 70s;
+
         access_by_lua_block {
             local routing = require "routing"
             local ds = require "lib/dataStore"


### PR DESCRIPTION
* Update proxy timeout for managed APIs to accommodate Whisk invokers returning a 202 shortly after 60s.

Currently, the Whisk invokers timeout after 60s and return a 202 with the activation ID. However, the gateway has a default read timeout of 60s, meaning that it hangs up just before the invoker returns the 202. This change allows the gateway to receive the 202 response.

@mhamann @alexsong93 PTAL