### PR TITLE
Decode empty JSON arrays correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk --update add \
     && rm -rf /var/cache/apk/*
 
 # openresty build
-ENV OPENRESTY_VERSION=1.13.6.1 \
+ENV OPENRESTY_VERSION=1.13.6.2 \
     PCRE_VERSION=8.37 \
     TEST_NGINX_VERSION=0.24 \
     OPM_VERSION=0.0.3 \

--- a/scripts/lua/routing.lua
+++ b/scripts/lua/routing.lua
@@ -19,6 +19,9 @@
 -- Used to dynamically handle nginx routing based on an object containing implementation details
 
 local cjson = require "cjson"
+if (cjson.decode_array_with_array_mt ~= nil) then
+  cjson.decode_array_with_array_mt(true)
+end
 local url = require "url"
 local utils = require "lib/utils"
 local request = require "lib/request"


### PR DESCRIPTION
Fixes issue where empty JSON arrays were getting converted to empty objects.

See https://github.com/openresty/lua-cjson#decode_array_with_array_mt.

@mhamann 