### PR TITLE
Update client_max_body_size for managed APIs

### DIFF
--- a/conf.d/managed_endpoints.conf
+++ b/conf.d/managed_endpoints.conf
@@ -72,6 +72,7 @@ server {
         set $responseBody '';
 
         proxy_read_timeout 70s;
+        client_max_body_size 5m;
 
         access_by_lua_block {
             local routing = require "routing"


### PR DESCRIPTION
* Increasing max payload size to 5m from the default 1m.

@mhamann PTAL