### PR TITLE
Security: Disable use of X-Accel-Redirect header

### DIFF
--- a/api-gateway.conf
+++ b/api-gateway.conf
@@ -61,6 +61,9 @@ pcre_jit on;
 http {
     default_type  text/plain;
 
+    # disallow usage of X-Accel-Redirect header
+    proxy_ignore_headers X-Accel-Redirect;
+
     # Set in-memory buffer size
     client_body_buffer_size 1M;
     client_max_body_size 1M;


### PR DESCRIPTION
This PR addresses a security issue in which web actions could access internal locations defined in the nginx config files by setting the X-Accel-Redirect response header.

*X-accel allows for internal redirection to a location determined by a header returned from a backend.*
see https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/
