### PR TITLE
package rename for whisk.core is now org.apache.openwhisk.core

### DIFF
--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -67,6 +67,6 @@ WSK_TESTS_DEPS_EXCLUDE=""
 
 TERM=dumb ./gradlew tests:test --tests apigw.healthtests.* ${WSK_TESTS_DEPS_EXCLUDE}
 sleep 60
-TERM=dumb ./gradlew tests:test --tests whisk.core.apigw.* ${WSK_TESTS_DEPS_EXCLUDE}
+TERM=dumb ./gradlew tests:test --tests org.apache.openwhisk..core.apigw.* ${WSK_TESTS_DEPS_EXCLUDE}
 sleep 60
-TERM=dumb ./gradlew tests:test --tests whisk.core.cli.test.ApiGwRestTests ${WSK_TESTS_DEPS_EXCLUDE}
+TERM=dumb ./gradlew tests:test --tests org.apache.openwhisk..core.cli.test.ApiGwRestTests ${WSK_TESTS_DEPS_EXCLUDE}

--- a/tools/travis/build.sh
+++ b/tools/travis/build.sh
@@ -67,6 +67,6 @@ WSK_TESTS_DEPS_EXCLUDE=""
 
 TERM=dumb ./gradlew tests:test --tests apigw.healthtests.* ${WSK_TESTS_DEPS_EXCLUDE}
 sleep 60
-TERM=dumb ./gradlew tests:test --tests org.apache.openwhisk..core.apigw.* ${WSK_TESTS_DEPS_EXCLUDE}
+TERM=dumb ./gradlew tests:test --tests org.apache.openwhisk.core.apigw.* ${WSK_TESTS_DEPS_EXCLUDE}
 sleep 60
-TERM=dumb ./gradlew tests:test --tests org.apache.openwhisk..core.cli.test.ApiGwRestTests ${WSK_TESTS_DEPS_EXCLUDE}
+TERM=dumb ./gradlew tests:test --tests org.apache.openwhisk.core.cli.test.ApiGwRestTests ${WSK_TESTS_DEPS_EXCLUDE}


### PR DESCRIPTION
unblocks #330 