### PR TITLE
Add paging to getTenantAPIs

### DIFF
--- a/scripts/lua/management/lib/tenants.lua
+++ b/scripts/lua/management/lib/tenants.lua
@@ -114,13 +114,27 @@ function _M.getTenantAPIs(dataStore, id, queryParams)
       end
     end
   end
-  -- Check for existence of paging parameters
-  if (queryParams['skip']  == nil and queryParams['limit'] == nil) then
+  if ((queryParams['skip']  == nil and queryParams['limit'] == nil) or table.getn(apiList) == 0) then
     return apiList
+  else
+    return applyPagingToAPIs(apiList, queryParams)
   end
-  -- Apply paging
-  local skip  = queryParams['skip']  == nil and 1 or queryParams['skip'] + 1
+end
+
+-- Apply paging on apis
+-- @param apis the list of apis
+-- @param queryparams object containing optional query parameters
+function applyPagingToAPIs(apiList, queryParams)
+  local skip  = queryParams['skip']  == nil and 1 or queryParams['skip']
   local limit = queryParams['limit'] == nil and table.getn(apiList) or queryParams['limit']
+  if (tonumber(limit) < 1) then
+    return {}
+  end
+  if (tonumber(skip) <= 0) then
+    skip = 1
+  else
+    skip = skip + 1
+  end
   if ((skip + limit - 1) > table.getn(apiList)) then
     limit = table.getn(apiList)
   else

--- a/scripts/lua/management/lib/tenants.lua
+++ b/scripts/lua/management/lib/tenants.lua
@@ -114,7 +114,25 @@ function _M.getTenantAPIs(dataStore, id, queryParams)
       end
     end
   end
-  return apiList
+  -- Check for existence of paging parameters
+  if (queryParams['skip']  == nil and queryParams['limit'] == nil) then
+    return apiList
+  end
+  -- Apply paging
+  local skip  = queryParams['skip']  == nil and 1 or queryParams['skip'] + 1
+  local limit = queryParams['limit'] == nil and table.getn(apiList) or queryParams['limit']
+  if ((skip + limit - 1) > table.getn(apiList)) then
+    limit = table.getn(apiList)
+  else
+    limit = skip + limit - 1
+  end
+  local apis  = {}
+  local idx   = 0
+  for i = skip, limit do
+    apis[idx] = apiList[i]
+    idx = idx + 1
+  end
+  return apis
 end
 
 --- Filter apis based on query paramters


### PR DESCRIPTION
This fix adds paging to the v2 getTenantAPIs api by honoring the skip and limit paramaters, if present in the request. This is to address issue #1692 in incubator-openwhisk.