### PR TITLE
Run test framework in a Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,24 +35,15 @@ notifications:
 
 env:
   global:
-    - LUA="lua=5.1"
     - secure: "c8XNwdOryMVJUGLzWv+AzUQaS0Yt7uUmGqw+5/K7o7zmpux7Q5H7OU3jni2kOr+ZoIldsmTnnG7m1N9D8qUjD64KaAfEC0ybo04kDraezVMghUEV8LWMpSRRlAFpzQeVC8IcSiUEXM0H8E6Y09jGMnLKqyFUWAlDB60n0x2rfK/IPU+x4/h+6Y5XpYqaNtujoUf/2XVkrOeRcEhVZQJAwsRtA8HjRUy7PRB/9kepTSln9QzRZYd6v4F1qUKgZhlWNRUXWRbhrNK/z6T7jSlHjY44yvse4fBbie+EsuImtOHnDuTA4XXQlbc0gGVvD3sYYf2CBMxeeE+UTbRPLxgml+uUIviWKt/PKB5qUwQyLKP/Rzr1qv5RryrX0xWoqCrVsaCe0fkh0vUks0AYlzhm1CNK/g1If+qZ6R0GMjawVUbCunhDi1vJlP5PmniIoLpVwLa6XoMYJKtfngGm2763y00ktVGGL1gDtnm0lDuhkinIxOzieh8aRpYDBX6zZZ/n20LzDO/5l0CGErKPgzzt9vRPiQNoGxqC90jtsin+XkOxF9erk0QYt/St7/Qa1R0E+0dA2bHqxz2SWz3cjcc4Cw8/DW3SLFjaONvs6aQyHkrL2LJabARMMgGmf68P5nJrPy56c3gV8jXe7CVaV+5nClT1HYgWSEIna6oyzo8kzFk="
     - secure: "dM0paMW2d4U4U7OwbnrTjdOqDnvo+nce9r7h+qTbYfbuJe0fpRkHCrxcB//8ESkMrPTr0EDExCxvaywY8pqeVVJbykNswdyze1SWYk6lbUvXTpSrKqp0J0a/FtVjfamc1aMv4c6KIDKh4vIcgK4xrjXj68COCS6uIcFhETNUy5bxH8T2BOJzyf/iWOF7oduXUV/VGNcWnhkPdoPh8xtpmBJ6ZTWQ01MriZ/28hvzgyh1OjJFWCJZ+OZoIDQVPb/jnfPXU4Wk/G/LEPJcBgvN4qSMr2lm3Iq29V0Ltrsx8rrYADO7trCm6qyEQK9TLKfywaYIcm/D9FJ8F4WBHtIeJ3PLY3518L3iZ+Ngd6QTnd0FI6hrG7rpoD/0dz4e//9d3tSsjbh/1BiQwXXTnPyaUjN3C92k4GyITYJTVL5f6evzsTneT6Plj1vWC0E52d1oqVOZDgrWMYZEHdYvpUJTQqclMNhu5SMIYAPqVvibqupcmAh5B+UDr6UvYT/hUAC/d3hyjfHgouRoluJ1mutND88QjDw6UWmXXjHqRSCI6OI5NDZczl/aqz7nPFyTaIe9EibTdZa5LC8fN+Am9MTRxJAv8HXt0zKe5FqHijSvFcVxYlhwlIZg7ShbPh+X2Hnh/JMjx0z/7ujkBRYfmAQW53SBy8Tv/Zv69nCz8eOFOUk="
 
 before_install:
   - ./tools/travis/scan.sh
   - ./tools/travis/setup.sh
-  - pip install hererocks --user
-  - hererocks lua_install -r^ --$LUA
-  - export PATH=$PATH:$PWD/lua_install/bin # Add directory with all installed binaries to PATH
-
-install:
-  - cd tests
-  - ./install-deps.sh
 
 script:
-  - busted --output=TAP --helper=set_paths --pattern=.lua scripts
-  - cd ..
+  - make test
   - ./tools/travis/build.sh
 
 deploy:

--- a/Dockerfile.test.unit
+++ b/Dockerfile.test.unit
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# apigateway
+#
+# VERSION               1.13.6.1
+#
+# From https://hub.docker.com/_/alpine/
+#
+
+FROM alpine:3.9
+
+RUN apk update && \
+    apk add \
+    gcc tar zlib wget make musl-dev g++ curl \
+    libtool readline luajit luajit-dev unzip \
+    openssl openssl-dev
+
+WORKDIR /tmp
+RUN wget https://luarocks.org/releases/luarocks-3.1.3.tar.gz && \
+    tar zxpf luarocks-3.1.3.tar.gz && \
+    cd luarocks-3.1.3 && \
+    ./configure && \
+    make build && \
+    make install
+
+COPY . /etc/api-gateway
+
+WORKDIR /etc/api-gateway/tests
+RUN ./install-deps.sh
+
+CMD sh run-tests.sh

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,10 @@ profile-run: profile-build
 		-e OPTIMIZE=1 \
 		-d ${PROFILING}
 
-.PHONY: test-run
-test-run:
-	cd tests; ./run-tests.sh
+.PHONY: test
+test:
+	docker build -f Dockerfile.test.unit -t gw-tests .
+	docker run gw-tests:latest
 
 .PHONY: docker-run
 docker-run:


### PR DESCRIPTION
This PR primarily moves the gateway unit test runs into their own docker container in order to make it easier to test locally. You can now avoid installing Lua and various deps onto your local machine and simply run `make test` to run all of the available units.

I also converted the main Dockerfile into a multi-stage build, which drastically improves build times for subsequent builds. A few syntax fixes are included as well, as Docker was throwing some warnings during builds.